### PR TITLE
Add Firefox option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Options:
   -b, --browser <browser>       Rendering browser. Choose 'chrome' (default) or 'firefox'.
   --viewports <viewports>       Viewports to take screenshots. e.g, `--viewports 1200,320`.
   --accept-language <language>  Accept language. The default is `en`. available with 'chrome' browser option.
-  --waitfor <seconds>           Number of seconds to wait for saving screenshots. The default is `3,000`.
+  --waitfor <seconds>           Number of seconds to wait for saving screenshots. The default is `3000`.
   -h, --help                    output usage information
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Usage: shootbot <URL>
 
 Options:
   -V, --version                 output the version number
-  -b, --browser <browser>       Rendering browser. Choose 'chrome' (default) or 'firefox'.
+  -b, --browser <browser>       Rendering browser. Choose `chrome` (default) or `firefox`.
   --viewports <viewports>       Viewports to take screenshots. e.g, `--viewports 1200,320`.
-  --accept-language <language>  Accept language. The default is `en`. available with 'chrome' browser option.
+  --accept-language <language>  Accept language. The default is `en`. available with `chrome` browser option.
   --waitfor <seconds>           Number of seconds to wait for saving screenshots. The default is `3000`.
   -h, --help                    output usage information
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A command that takes screenshots from the specfic URL for multiple viewports.
 $ shootbot <URL>
 ```
 
+```shell
+$ shootbot <URL> --browser=firefox
+```
+
 ### Default viewports
 
 * 1200

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ A command that takes screenshots from the specfic URL for multiple viewports.
 $ shootbot <URL>
 ```
 
-```shell
-$ shootbot <URL> --browser=firefox
+Specify a browser.
+
+```
+$ shootbot <URL> -b firefox
 ```
 
 ### Default viewports

--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ program
   .option('-b, --browser <browser>', 'Rendering browser. Choose `chrome` (default) or `firefox`.')
   .option('--viewports <viewports>', 'Viewports to take screenshots. e.g, `--viewports 1200,320`.')
   .option('--accept-language <language>', 'Accept language. The default is `en`. available with `chrome` browser option.')
-  .option('--waitfor <seconds>', 'Number of seconds to wait for saving screenshots. The default is `3000`.')
+  .option('--waitfor <seconds>', 'Number of seconds to wait for saving screenshots. The default is `3,000`.')
   .parse(process.argv);
 
 if (0 === program.args.length) {

--- a/cli.js
+++ b/cli.js
@@ -3,13 +3,20 @@
 'use strict';
 
 const program = require('commander');
-const puppeteer = require('puppeteer');
+const puppeteerChrome = require('puppeteer');
+const puppeteerFirefox = require('puppeteer-firefox');
 const pkg = require('./package.json');
+
+const browsers = {
+  chrome: { puppeteer: puppeteerChrome, isDefault: true },
+  firefox: {puppeteer: puppeteerFirefox },
+}
 
 program
   .version(pkg.version)
   .usage('<URL>')
-.parse(process.argv);
+  .option('-b, --browser [type]', 'specify a browser. Choose \'chrome\' [default] or \'firefox\'')
+  .parse(process.argv);
 
 const viewports = [
   1200,
@@ -23,20 +30,30 @@ if (0 === program.args.length) {
   process.exit(1);
 }
 
-async function saveScreenshot(url, viewport) {
+async function saveScreenshot(url, viewport, type) {
+  const puppeteer = browsers[type].puppeteer
+  const isDefault = browsers[type].isDefault
   const file = url.replace(/https?:\/\//, '').replace(/\/$/, '').replace(/\//g, '-')
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.setViewport({width: viewport, height: 800})
   await page.goto(url)
+  const filename = (isDefault ? [file, viewport] : [file, viewport, type]).join('-') + '.png'
   await setTimeout(async () => {
-    await page.screenshot({path: file + '-' + viewport + '.png', fullPage: true})
+    await page.screenshot({path: filename, fullPage: true})
     await browser.close()
   }, 5000)
 }
 
 const url = program.args[0]
+const type = (program.browser || 'chrome').toLowerCase()
+
+if (!browsers[type]) {
+  program.outputHelp();
+  process.exit(2)
+}
+
 for (let i = 0; i < viewports.length; i++) {
   const viewport = viewports[i]
-  saveScreenshot(url, viewport)
+  saveScreenshot(url, viewport, type)
 }

--- a/cli.js
+++ b/cli.js
@@ -15,10 +15,10 @@ const browsers = {
 program
   .version(pkg.version)
   .usage('<URL>')
-  .option('-b, --browser <browser>', 'Rendering browser. Choose \'chrome\' (default) or \'firefox\'.')
+  .option('-b, --browser <browser>', 'Rendering browser. Choose `chrome` (default) or `firefox`.')
   .option('--viewports <viewports>', 'Viewports to take screenshots. e.g, `--viewports 1200,320`.')
-  .option('--accept-language <language>', 'Accept language. The default is `en`. available with \'chrome\' browser option.')
-  .option('--waitfor <seconds>', 'Number of seconds to wait for saving screenshots. The default is `3,000`.')
+  .option('--accept-language <language>', 'Accept language. The default is `en`. available with `chrome` browser option.')
+  .option('--waitfor <seconds>', 'Number of seconds to wait for saving screenshots. The default is `3000`.')
   .parse(process.argv);
 
 if (0 === program.args.length) {

--- a/cli.js
+++ b/cli.js
@@ -53,20 +53,20 @@ const saveScreenshot = async (url, viewport, selectedBrowser) => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
-  let filename
+  let path
   if (isDefaultBrowser) {
     // firefox-puppeteer@0.4.2 doesn't support `setExtraHTTPHeaders`
     await page.setExtraHTTPHeaders({
       'Accept-Language': lang
     })
-    filename = file + '-' + lang + '-' + viewport + '.png'
+    path = file + '-' + lang + '-' + viewport + '.png'
   } else {
-    filename = file + '-' + viewport + '-' + selectedBrowser + '.png'
+    path = file + '-' + viewport + '-' + selectedBrowser + '.png'
   }
   await page.setViewport({width: parseInt(viewport), height: 800})
   await page.goto(url, {waitUntil: "domcontentloaded"}).then(() => {
     setTimeout(async () => {
-      await page.screenshot({path: filename, fullPage: true})
+      await page.screenshot({path: path, fullPage: true})
       await browser.close()
     }, waitfor)
   }).catch((e) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tilecloud/shootbot",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -250,6 +250,20 @@
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
         "ws": "^6.1.0"
+      }
+    },
+    "puppeteer-firefox": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-firefox/-/puppeteer-firefox-0.4.2.tgz",
+      "integrity": "sha512-amdsZixPZUyUHyepYCsG2yLH4Ugojnakf43/b/2IEDWGqI/gKaVvj60QJsXX4AeZLeyITnUKK6YiR69Rs8akMA==",
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1"
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^2.19.0",
-    "puppeteer": "^1.11.0"
+    "puppeteer": "^1.11.0",
+    "puppeteer-firefox": "^0.4.2"
   }
 }


### PR DESCRIPTION
Puppeteer team also provides Firefox API!
https://www.npmjs.com/package/puppeteer-firefox

This pull request enable option to use Firefox.

Though `puppeteer-firefox` is experimental, it working well.